### PR TITLE
Allow recent Node.js versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/kkpoon/strapi-provider-upload-aws-s3-custom-domain/issues"
   },
   "engines": {
-    "node": "^10.0.0",
+    "node": ">=10.0.0",
     "npm": ">= 6.0.0"
   },
   "license": "MIT",


### PR DESCRIPTION
Currently people with Node v11 and above can't use this, although they're still compatible.